### PR TITLE
ObsidianReplaceModule use Material.isReplaceable()

### DIFF
--- a/src/main/java/me/rigamortis/seppuku/impl/module/combat/ObsidianReplaceModule.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/module/combat/ObsidianReplaceModule.java
@@ -74,8 +74,7 @@ public final class ObsidianReplaceModule extends Module {
                     if (pos != null) {
                         final double dist = mc.player.getDistance(pos.getX(), pos.getY(), pos.getZ());
                         if (dist <= 5.0f) {
-                            final Block block = mc.world.getBlockState(pos).getBlock();
-                            if (block instanceof BlockAir || block instanceof BlockLiquid) {
+                            if (mc.world.getBlockState(pos).getMaterial().isReplaceable()) {
                                 if (this.valid(pos)) {
                                     this.place(pos);
                                     valid = true;
@@ -112,8 +111,7 @@ public final class ObsidianReplaceModule extends Module {
             if (pos != null) {
                 final double dist = mc.player.getDistance(pos.getX(), pos.getY(), pos.getZ());
                 if (dist <= 5.0f) {
-                    final Block block = mc.world.getBlockState(pos).getBlock();
-                    if (block instanceof BlockAir || block instanceof BlockLiquid) {
+                    if (mc.world.getBlockState(pos).getMaterial().isReplaceable()) {
                         if (this.valid(pos)) {
                             return true;
                         }

--- a/src/main/java/me/rigamortis/seppuku/impl/module/combat/ObsidianReplaceModule.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/module/combat/ObsidianReplaceModule.java
@@ -130,7 +130,7 @@ public final class ObsidianReplaceModule extends Module {
             if (this.mode.getInt() == 1) {
                 if (event.getPacket() instanceof SPacketBlockChange) {
                     final SPacketBlockChange packet = (SPacketBlockChange) event.getPacket();
-                    if (packet.getBlockState().getBlock() instanceof BlockAir) {
+                    if (packet.getBlockState().getMaterial().isReplaceable()) {
                         final double dist = mc.player.getDistance(packet.getBlockPosition().getX(), packet.getBlockPosition().getY(), packet.getBlockPosition().getZ());
                         if (dist <= 5.0f) {
                             if (!this.blocks.contains(packet.getBlockPosition())) {


### PR DESCRIPTION
This includes snow and grass etc. when checking for placeability. Im not sure the check for BlockAir and BlockLiquid only is on purpose, but i could not find a reason for not using isReplaceable().