### PR TITLE
ObsidianReplace ignore non LivingBase Entities

### DIFF
--- a/src/main/java/me/rigamortis/seppuku/impl/module/combat/ObsidianReplaceModule.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/module/combat/ObsidianReplaceModule.java
@@ -341,7 +341,7 @@ public final class ObsidianReplaceModule extends Module {
         }
 
         for (Entity entity : mc.world.getEntitiesWithinAABBExcludingEntity(null, new AxisAlignedBB(pos))) {
-            if (!(entity instanceof EntityItem)) {
+            if (!(entity instanceof EntityItem) && !(entity instanceof EntityXPOrb)) {
                 return false;
             }
         }

--- a/src/main/java/me/rigamortis/seppuku/impl/module/combat/ObsidianReplaceModule.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/module/combat/ObsidianReplaceModule.java
@@ -11,10 +11,15 @@ import me.rigamortis.seppuku.api.util.MathUtil;
 import me.rigamortis.seppuku.api.util.RenderUtil;
 import me.rigamortis.seppuku.api.value.OptionalValue;
 import me.rigamortis.seppuku.impl.module.player.FreeCamModule;
-import net.minecraft.block.*;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockAir;
+import net.minecraft.block.BlockLiquid;
+import net.minecraft.block.BlockObsidian;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemBlock;
@@ -344,8 +349,13 @@ public final class ObsidianReplaceModule extends Module {
         final Block east = mc.world.getBlockState(pos.add(1, 0, 0)).getBlock();
         final Block west = mc.world.getBlockState(pos.add(-1, 0, 0)).getBlock();
 
+        for (Entity entity : mc.world.getEntitiesWithinAABBExcludingEntity(null, new AxisAlignedBB(pos))) {
+            if (entity instanceof EntityLivingBase) {
+                return false;
+            }
+        }
+
         return (block instanceof BlockAir)
-                && mc.world.getEntitiesWithinAABBExcludingEntity(null, new AxisAlignedBB(pos)).isEmpty()
                 && ((up != null && up != Blocks.AIR && !(up instanceof BlockLiquid))
                 || (down != null && down != Blocks.AIR && !(down instanceof BlockLiquid))
                 || (north != null && north != Blocks.AIR && !(north instanceof BlockLiquid))

--- a/src/main/java/me/rigamortis/seppuku/impl/module/combat/ObsidianReplaceModule.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/module/combat/ObsidianReplaceModule.java
@@ -79,12 +79,9 @@ public final class ObsidianReplaceModule extends Module {
                     if (pos != null) {
                         final double dist = mc.player.getDistance(pos.getX(), pos.getY(), pos.getZ());
                         if (dist <= 5.0f) {
-                            final Block block = mc.world.getBlockState(pos).getBlock();
-                            if (block instanceof BlockAir || block instanceof BlockLiquid) {
-                                if (this.valid(pos)) {
-                                    this.place(pos);
-                                    valid = true;
-                                }
+                            if (this.valid(pos)) {
+                                this.place(pos);
+                                valid = true;
                             }
                         }
                     }
@@ -117,11 +114,8 @@ public final class ObsidianReplaceModule extends Module {
             if (pos != null) {
                 final double dist = mc.player.getDistance(pos.getX(), pos.getY(), pos.getZ());
                 if (dist <= 5.0f) {
-                    final Block block = mc.world.getBlockState(pos).getBlock();
-                    if (block instanceof BlockAir || block instanceof BlockLiquid) {
-                        if (this.valid(pos)) {
-                            return true;
-                        }
+                    if (this.valid(pos)) {
+                        return true;
                     }
                 }
             }
@@ -342,12 +336,9 @@ public final class ObsidianReplaceModule extends Module {
     private boolean valid(BlockPos pos) {
         final Block block = mc.world.getBlockState(pos).getBlock();
 
-        final Block up = mc.world.getBlockState(pos.add(0, 1, 0)).getBlock();
-        final Block down = mc.world.getBlockState(pos.add(0, -1, 0)).getBlock();
-        final Block north = mc.world.getBlockState(pos.add(0, 0, -1)).getBlock();
-        final Block south = mc.world.getBlockState(pos.add(0, 0, 1)).getBlock();
-        final Block east = mc.world.getBlockState(pos.add(1, 0, 0)).getBlock();
-        final Block west = mc.world.getBlockState(pos.add(-1, 0, 0)).getBlock();
+        if (!(block instanceof BlockAir) && !(block instanceof BlockLiquid)) {
+            return false;
+        }
 
         for (Entity entity : mc.world.getEntitiesWithinAABBExcludingEntity(null, new AxisAlignedBB(pos))) {
             if (entity instanceof EntityLivingBase) {
@@ -355,8 +346,14 @@ public final class ObsidianReplaceModule extends Module {
             }
         }
 
-        return (block instanceof BlockAir)
-                && ((up != null && up != Blocks.AIR && !(up instanceof BlockLiquid))
+        final Block up = mc.world.getBlockState(pos.add(0, 1, 0)).getBlock();
+        final Block down = mc.world.getBlockState(pos.add(0, -1, 0)).getBlock();
+        final Block north = mc.world.getBlockState(pos.add(0, 0, -1)).getBlock();
+        final Block south = mc.world.getBlockState(pos.add(0, 0, 1)).getBlock();
+        final Block east = mc.world.getBlockState(pos.add(1, 0, 0)).getBlock();
+        final Block west = mc.world.getBlockState(pos.add(-1, 0, 0)).getBlock();
+
+        return ((up != null && up != Blocks.AIR && !(up instanceof BlockLiquid))
                 || (down != null && down != Blocks.AIR && !(down instanceof BlockLiquid))
                 || (north != null && north != Blocks.AIR && !(north instanceof BlockLiquid))
                 || (south != null && south != Blocks.AIR && !(south instanceof BlockLiquid))

--- a/src/main/java/me/rigamortis/seppuku/impl/module/combat/ObsidianReplaceModule.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/module/combat/ObsidianReplaceModule.java
@@ -19,7 +19,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemBlock;
@@ -341,7 +341,7 @@ public final class ObsidianReplaceModule extends Module {
         }
 
         for (Entity entity : mc.world.getEntitiesWithinAABBExcludingEntity(null, new AxisAlignedBB(pos))) {
-            if (entity instanceof EntityLivingBase) {
+            if (!(entity instanceof EntityItem)) {
                 return false;
             }
         }

--- a/src/main/java/me/rigamortis/seppuku/impl/module/combat/ObsidianReplaceModule.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/module/combat/ObsidianReplaceModule.java
@@ -20,6 +20,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.item.EntityXPOrb;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemBlock;


### PR DESCRIPTION
This ignores non EntityLivingBase Entities when doing valid() place check.
Also refactored duplicated logic.