### PR TITLE
Quality of Life: Sort Modules/Commands alphabetically

### DIFF
--- a/src/main/java/me/rigamortis/seppuku/impl/management/CommandManager.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/management/CommandManager.java
@@ -12,6 +12,8 @@ import net.minecraft.util.text.TextComponentString;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -70,6 +72,8 @@ public final class CommandManager {
 
         //load our external commands
         loadExternalCommands();
+
+        Collections.sort(commandList, Comparator.comparing(Command::getDisplayName));
     }
 
     /**

--- a/src/main/java/me/rigamortis/seppuku/impl/management/ModuleManager.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/management/ModuleManager.java
@@ -18,11 +18,12 @@ import me.rigamortis.seppuku.impl.module.player.*;
 import me.rigamortis.seppuku.impl.module.render.*;
 import me.rigamortis.seppuku.impl.module.ui.HudEditorModule;
 import me.rigamortis.seppuku.impl.module.world.*;
-import net.minecraft.client.Minecraft;
 
 import java.io.File;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -154,6 +155,8 @@ public final class ModuleManager {
 
         for (final Module module : moduleList)
             Seppuku.INSTANCE.getEventManager().dispatchEvent(new EventModulePostLoaded(module));
+
+        Collections.sort(moduleList, Comparator.comparing(Module::getDisplayName));
     }
 
     /**


### PR DESCRIPTION
Not sure I really need to do any explaining on this one.
This change sorts all the modules and commands on startup, like so:
![image](https://user-images.githubusercontent.com/40577357/70577852-1164cc00-1b7a-11ea-9ee5-cfd96f6cc781.png)
![image](https://user-images.githubusercontent.com/40577357/70577862-175aad00-1b7a-11ea-850e-2c287b5d9455.png)
