### PR TITLE
Lots of changes, see comment

### DIFF
--- a/src/main/java/me/rigamortis/seppuku/api/gui/hud/component/BlocksComponent.java
+++ b/src/main/java/me/rigamortis/seppuku/api/gui/hud/component/BlocksComponent.java
@@ -114,23 +114,9 @@ public final class BlocksComponent extends HudComponent {
                             sprite = Minecraft.getMinecraft().getTextureMapBlocks().getTextureExtry(fluidStill.toString());
                         }
 
-                        final int fluidColor = fluid.getColor();
-                        final float r = (float)(fluidColor >> 16 & 255) / 255.0F;
-                        final float g = (float)(fluidColor >> 8 & 255) / 255.0F;
-                        final float b = (float)(fluidColor & 255) / 255.0F;
-                        GlStateManager.color(r, g, b, 1.0f);
-
-                        Minecraft.getMinecraft().renderEngine.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
-                        final Tessellator tessellator = Tessellator.getInstance();
-                        final BufferBuilder bufferBuilder = tessellator.getBuffer();
-                        bufferBuilder.begin(7, DefaultVertexFormats.POSITION_TEX);
+                        RenderUtil.glColor(fluid.getColor());
                         // Note that fluids are a full quad; extra padding is added so that you can see the background to check whether the block is selected or not
-                        bufferBuilder.pos((double)(rectX + 1), (double)(rectY + 15), 0d).tex((double)sprite.getMinU(), (double)sprite.getMaxV()).endVertex();
-                        bufferBuilder.pos((double)(rectX + 15), (double)(rectY + 15), 0d).tex((double)sprite.getMaxU(), (double)sprite.getMaxV()).endVertex();
-                        bufferBuilder.pos((double)(rectX + 15), (double)(rectY + 1), 0d).tex((double)sprite.getMaxU(), (double)sprite.getMinV()).endVertex();
-                        bufferBuilder.pos((double)(rectX + 1), (double)(rectY + 1), 0d).tex((double)sprite.getMinU(), (double)sprite.getMinV()).endVertex();
-                        tessellator.draw();
-
+                        RenderUtil.drawTexture(rectX + 1, rectY + 1, 14, 14, sprite.getMinU(), sprite.getMinV(), sprite.getMaxU(), sprite.getMaxV());
                     } else {
                         final ItemStack itemStack = new ItemStack(block);
                         Minecraft.getMinecraft().getRenderItem().renderItemIntoGUI(itemStack, (int) renderPaddingX + (int) this.getX() + xOffset, (int) renderPaddingY + (int) this.getY() + yOffset);

--- a/src/main/java/me/rigamortis/seppuku/api/gui/hud/component/BlocksComponent.java
+++ b/src/main/java/me/rigamortis/seppuku/api/gui/hud/component/BlocksComponent.java
@@ -162,8 +162,8 @@ public final class BlocksComponent extends HudComponent {
     public void mouseClick(int mouseX, int mouseY, int button) {
         super.mouseClick(mouseX, mouseY, button);
 
-        if (this.searchBox.displayValue.equals("..."))
-            this.searchBox.displayValue = "";
+        if (this.searchBox.getText().equals("..."))
+            this.searchBox.setText("");
 
         this.searchBox.mouseClick(mouseX, mouseY, button);
     }
@@ -212,7 +212,7 @@ public final class BlocksComponent extends HudComponent {
         super.keyTyped(typedChar, keyCode);
         this.searchBox.keyTyped(typedChar, keyCode);
 
-        if (this.searchBox.displayValue.equals("") && this.displayedBlocks.size() != 0) {
+        if (this.searchBox.getText().equals("") && this.displayedBlocks.size() != 0) {
             this.displayedBlocks.clear();
             this.displayedBlocks.addAll(this.blocks);
         } else {
@@ -220,9 +220,9 @@ public final class BlocksComponent extends HudComponent {
         }
 
         for (Block block : this.blocks) {
-            if (CharUtils.isAsciiNumeric(typedChar) && NumberUtils.isDigits(this.searchBox.displayValue)) {
+            if (CharUtils.isAsciiNumeric(typedChar) && NumberUtils.isDigits(this.searchBox.getText())) {
                 final int blockID = Block.getIdFromBlock(block);
-                if (blockID == Integer.parseInt(this.searchBox.displayValue)) {
+                if (blockID == Integer.parseInt(this.searchBox.getText())) {
                     if (!this.displayedBlocks.contains(block)) {
                         this.displayedBlocks.add(block);
                     }
@@ -230,7 +230,7 @@ public final class BlocksComponent extends HudComponent {
             } else {
                 final ResourceLocation registryName = block.getRegistryName();
                 if (registryName != null) {
-                    if (registryName.toString().contains(this.searchBox.displayValue)) {
+                    if (registryName.toString().contains(this.searchBox.getText())) {
                         if (!this.displayedBlocks.contains(block)) {
                             this.displayedBlocks.add(block);
                         }

--- a/src/main/java/me/rigamortis/seppuku/api/gui/hud/component/ItemsComponent.java
+++ b/src/main/java/me/rigamortis/seppuku/api/gui/hud/component/ItemsComponent.java
@@ -122,8 +122,8 @@ public final class ItemsComponent extends HudComponent {
     public void mouseClick(int mouseX, int mouseY, int button) {
         super.mouseClick(mouseX, mouseY, button);
 
-        if (this.searchBox.displayValue.equals("..."))
-            this.searchBox.displayValue = "";
+        if (this.searchBox.getText().equals("..."))
+            this.searchBox.setText("");
 
         this.searchBox.mouseClick(mouseX, mouseY, button);
     }
@@ -172,7 +172,7 @@ public final class ItemsComponent extends HudComponent {
         super.keyTyped(typedChar, keyCode);
         this.searchBox.keyTyped(typedChar, keyCode);
 
-        if (this.searchBox.displayValue.equals("") && this.displayedItems.size() != 0) {
+        if (this.searchBox.getText().equals("") && this.displayedItems.size() != 0) {
             this.displayedItems.clear();
             this.displayedItems.addAll(this.items);
         } else {
@@ -180,9 +180,9 @@ public final class ItemsComponent extends HudComponent {
         }
 
         for (Item item : this.items) {
-            if (CharUtils.isAsciiNumeric(typedChar) && NumberUtils.isDigits(this.searchBox.displayValue)) {
+            if (CharUtils.isAsciiNumeric(typedChar) && NumberUtils.isDigits(this.searchBox.getText())) {
                 final int itemID = Item.getIdFromItem(item);
-                if (itemID == Integer.parseInt(this.searchBox.displayValue)) {
+                if (itemID == Integer.parseInt(this.searchBox.getText())) {
                     if (!this.displayedItems.contains(item)) {
                         this.displayedItems.add(item);
                     }
@@ -190,7 +190,7 @@ public final class ItemsComponent extends HudComponent {
             } else {
                 final ResourceLocation registryName = item.getRegistryName();
                 if (registryName != null) {
-                    if (registryName.toString().contains(this.searchBox.displayValue)) {
+                    if (registryName.toString().contains(this.searchBox.getText())) {
                         if (!this.displayedItems.contains(item)) {
                             this.displayedItems.add(item);
                         }

--- a/src/main/java/me/rigamortis/seppuku/api/gui/hud/component/SliderComponent.java
+++ b/src/main/java/me/rigamortis/seppuku/api/gui/hud/component/SliderComponent.java
@@ -219,15 +219,15 @@ public final class SliderComponent extends HudComponent {
                         public void onComponentEvent() {
                             try {
                                 if (value.getValue() instanceof Integer) {
-                                    value.setValue(Integer.parseInt(valueNumberText.displayValue));
+                                    value.setValue(Integer.parseInt(valueNumberText.getText()));
                                 } else if (value.getValue() instanceof Double) {
-                                    value.setValue(Double.parseDouble(valueNumberText.displayValue));
+                                    value.setValue(Double.parseDouble(valueNumberText.getText()));
                                 } else if (value.getValue() instanceof Float) {
-                                    value.setValue(Float.parseFloat(valueNumberText.displayValue));
+                                    value.setValue(Float.parseFloat(valueNumberText.getText()));
                                 } else if (value.getValue() instanceof Long) {
-                                    value.setValue(Long.parseLong(valueNumberText.displayValue));
+                                    value.setValue(Long.parseLong(valueNumberText.getText()));
                                 } else if (value.getValue() instanceof Byte) {
-                                    value.setValue(Byte.parseByte(valueNumberText.displayValue));
+                                    value.setValue(Byte.parseByte(valueNumberText.getText()));
                                 }
                                 Seppuku.INSTANCE.getConfigManager().save(ModuleConfig.class); // save module configs
                             } catch (NumberFormatException e) {

--- a/src/main/java/me/rigamortis/seppuku/api/util/GLUProjection.java
+++ b/src/main/java/me/rigamortis/seppuku/api/util/GLUProjection.java
@@ -3,6 +3,7 @@ package me.rigamortis.seppuku.api.util;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.util.glu.GLU;
 import org.lwjgl.util.vector.Matrix4f;
+import org.lwjgl.util.vector.Vector4f;
 
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
@@ -319,11 +320,13 @@ public final class GLUProjection {
         } else {
             pitch = -Math.toDegrees(Math.atan2(nuv.cross(uv).length(), nuv.dot(uv)));
         }
-        this.lookVec = this.getRotationVector(yaw, pitch);
         //Get modelview matrix and invert it
         Matrix4f modelviewMatrix = new Matrix4f();
         modelviewMatrix.load(this.modelview.asReadOnlyBuffer());
         modelviewMatrix.invert();
+        //Get look vector (forward) from modelview matrix
+        Vector4f forward = Matrix4f.transform(modelviewMatrix, new Vector4f(0, 0, -1, 0), null);
+        this.lookVec = new Vector3D(forward.x, forward.y, forward.z).snormalize();
         //Get frustum position
         this.frustumPos = new Vector3D(modelviewMatrix.m30, modelviewMatrix.m31, modelviewMatrix.m32);
         this.frustum = this.getFrustum(this.frustumPos.x, this.frustumPos.y, this.frustumPos.z, yaw, pitch, fov, 1.0F, displayWidth / displayHeight);
@@ -577,6 +580,15 @@ public final class GLUProjection {
      */
     public Vector3D getLookVector() {
         return this.lookVec;
+    }
+
+    /**
+     * Returns the camera position (frustumPos) updated with {@link GLUProjection#updateMatrices(IntBuffer, FloatBuffer, FloatBuffer, double, double)}
+     *
+     * @return
+     */
+    public Vector3D getCamPos() {
+        return this.frustumPos;
     }
 
     /**

--- a/src/main/java/me/rigamortis/seppuku/api/util/RenderUtil.java
+++ b/src/main/java/me/rigamortis/seppuku/api/util/RenderUtil.java
@@ -36,7 +36,7 @@ public final class RenderUtil {
         GLUProjection.getInstance().updateMatrices(VIEWPORT, MODELVIEW, PROJECTION, (float) res.getScaledWidth() / (float) Minecraft.getMinecraft().displayWidth, (float) res.getScaledHeight() / (float) Minecraft.getMinecraft().displayHeight);
     }
 
-    public static void drawRect(float x, float y, float w, float h, int color) {
+    public static void drawRect(float left, float top, float right, float bottom, int color) {
         float alpha = (float) (color >> 24 & 255) / 255.0F;
         float red = (float) (color >> 16 & 255) / 255.0F;
         float green = (float) (color >> 8 & 255) / 255.0F;
@@ -47,10 +47,10 @@ public final class RenderUtil {
         GlStateManager.disableTexture2D();
         GlStateManager.tryBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, 1, 0);
         bufferbuilder.begin(7, DefaultVertexFormats.POSITION_COLOR);
-        bufferbuilder.pos(x, h, 0.0D).color(red, green, blue, alpha).endVertex();
-        bufferbuilder.pos(w, h, 0.0D).color(red, green, blue, alpha).endVertex();
-        bufferbuilder.pos(w, y, 0.0D).color(red, green, blue, alpha).endVertex();
-        bufferbuilder.pos(x, y, 0.0D).color(red, green, blue, alpha).endVertex();
+        bufferbuilder.pos(left, bottom, 0.0D).color(red, green, blue, alpha).endVertex();
+        bufferbuilder.pos(right, bottom, 0.0D).color(red, green, blue, alpha).endVertex();
+        bufferbuilder.pos(right, top, 0.0D).color(red, green, blue, alpha).endVertex();
+        bufferbuilder.pos(left, top, 0.0D).color(red, green, blue, alpha).endVertex();
         tessellator.draw();
         GlStateManager.enableTexture2D();
         GlStateManager.disableBlend();

--- a/src/main/java/me/rigamortis/seppuku/api/util/RenderUtil.java
+++ b/src/main/java/me/rigamortis/seppuku/api/util/RenderUtil.java
@@ -636,13 +636,7 @@ public final class RenderUtil {
     }
 
     public static void drawSphere(float radius, int slices, int stacks, int color) {
-        final float alpha = (color >> 24 & 0xFF) / 255.0F;
-        final float red = (color >> 16 & 0xFF) / 255.0F;
-        final float green = (color >> 8 & 0xFF) / 255.0F;
-        final float blue = (color & 0xFF) / 255.0F;
-
-        glColor4f(red, green, blue, alpha);
-
+        glColor(color);
         new Sphere().draw(radius, slices, stacks);
     }
 
@@ -718,7 +712,7 @@ public final class RenderUtil {
         float red = (hex >> 16 & 0xFF) / 255.0F;
         float green = (hex >> 8 & 0xFF) / 255.0F;
         float blue = (hex & 0xFF) / 255.0F;
-        GL11.glColor4f(red, green, blue, alpha);
+        GlStateManager.color(red, green, blue, alpha);
     }
 
     public static void glColor(int redRGB, int greenRGB, int blueRGB, int alphaRGB) {
@@ -726,7 +720,7 @@ public final class RenderUtil {
         float green = 0.003921569F * greenRGB;
         float blue = 0.003921569F * blueRGB;
         float alpha = 0.003921569F * alphaRGB;
-        GL11.glColor4f(red, green, blue, alpha);
+        GlStateManager.color(red, green, blue, alpha);
     }
 
     public static void begin2D() {

--- a/src/main/java/me/rigamortis/seppuku/api/util/StringUtil.java
+++ b/src/main/java/me/rigamortis/seppuku/api/util/StringUtil.java
@@ -141,4 +141,51 @@ public final class StringUtil {
         }
         return sb.toString();
     }
+
+    /**
+     * Insert a string inside another string at a given position. Does not check
+     * for bounds and therefore may throw.
+     * @param original The original string, where the insertion string will be put
+     * @param insertion The string to insert
+     * @param position Where to insert the string at
+     * @returns the final string
+     */
+    public static String insertAt(String original, String insertion, int position) {
+        return new StringBuilder(original.length() + insertion.length())
+            .append(original, 0, position)
+            .append(insertion)
+            .append(original,position, original.length())
+            .toString();
+    }
+
+    /**
+     * Insert a character inside another string at a given position. Does not
+     * check for bounds and therefore may throw.
+     * @param original The original string, where the insertion string will be put
+     * @param insertion The character to insert
+     * @param position Where to insert the character at
+     * @returns the final string
+     */
+    public static String insertAt(String original, char insertion, int position) {
+        return new StringBuilder(original.length() + 1)
+            .append(original, 0, position)
+            .append(insertion)
+            .append(original,position, original.length())
+            .toString();
+    }
+
+    /**
+     * Delete a range of characters in a string. Does not check for bounds and
+     * therefore may throw.
+     * @param s The string to manipulate
+     * @param start The start of the range
+     * @param end The end of the range (exclusive; character at this position not removed)
+     * @returns the final string
+     */
+    public static String removeRange(String s, int start, int end) {
+        return new StringBuilder(s.length() + start - end)
+            .append(s, 0, start)
+            .append(s, end, s.length())
+            .toString();
+    }
 }

--- a/src/main/java/me/rigamortis/seppuku/impl/gui/hud/GuiHudEditor.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/gui/hud/GuiHudEditor.java
@@ -29,6 +29,8 @@ public final class GuiHudEditor extends GuiScreen {
     public void initGui() {
         super.initGui();
 
+        Keyboard.enableRepeatEvents(true);
+
         this.particlesComponent = (ParticlesComponent) Seppuku.INSTANCE.getHudManager().findComponent(ParticlesComponent.class);
         if (particlesComponent != null) {
             if (particlesComponent.isVisible()) {
@@ -185,6 +187,7 @@ public final class GuiHudEditor extends GuiScreen {
     @Override
     public void onGuiClosed() {
         //Seppuku.INSTANCE.getConfigManager().saveAll();
+        Keyboard.enableRepeatEvents(false);
 
         final HudEditorModule hudEditorModule = (HudEditorModule) Seppuku.INSTANCE.getModuleManager().find(HudEditorModule.class);
         if (hudEditorModule != null) {

--- a/src/main/java/me/rigamortis/seppuku/impl/gui/hud/component/ColorsComponent.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/gui/hud/component/ColorsComponent.java
@@ -374,7 +374,7 @@ public final class ColorsComponent extends ResizableHudComponent {
                         this.selectedColor = colorAtMouseClick.getRGB();
                         this.currentColorComponent.setCurrentColor(colorAtMouseClick);
                         this.currentColorComponent.returnListener.onComponentEvent();
-                        this.currentColorComponent.displayValue = "#" + Integer.toHexString(this.selectedColor).toLowerCase().substring(2);
+                        this.currentColorComponent.setText("#" + Integer.toHexString(this.selectedColor).toLowerCase().substring(2));
                         this.lastSpectrumMouseX = mouseX;
                         this.lastSpectrumMouseY = mouseY;
                     } else {

--- a/src/main/java/me/rigamortis/seppuku/impl/gui/hud/component/module/ModuleListComponent.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/gui/hud/component/module/ModuleListComponent.java
@@ -464,7 +464,7 @@ public final class ModuleListComponent extends ResizableHudComponent {
                 public void onKeyTyped(int keyCode) {
                     if (keyCode == Keyboard.KEY_ESCAPE) {
                         module.setKey("NONE");
-                        keybindText.displayValue = "none";
+                        keybindText.setText("none");
                         keybindText.focused = false;
                         // re-open the hud editor
                         final HudEditorModule hudEditorModule = (HudEditorModule) Seppuku.INSTANCE.getModuleManager().find(HudEditorModule.class);
@@ -474,7 +474,7 @@ public final class ModuleListComponent extends ResizableHudComponent {
                     } else {
                         String newKey = Keyboard.getKeyName(keyCode);
                         module.setKey(newKey);
-                        keybindText.displayValue = newKey.length() == 1 /* is letter */ ? newKey.substring(1) : newKey.toLowerCase();
+                        keybindText.setText(newKey.length() == 1 /* is letter */ ? newKey.substring(1) : newKey.toLowerCase());
                         keybindText.focused = false;
                     }
                 }
@@ -574,8 +574,8 @@ public final class ModuleListComponent extends ResizableHudComponent {
                     valueText.returnListener = new ComponentListener() {
                         @Override
                         public void onComponentEvent() {
-                            if (value.getEnum(valueText.displayValue) != -1) {
-                                value.setEnumValue(valueText.displayValue);
+                            if (value.getEnum(valueText.getText()) != -1) {
+                                value.setEnumValue(valueText.getText());
                                 Seppuku.INSTANCE.getConfigManager().save(ModuleConfig.class); // save configs
                                 Seppuku.INSTANCE.getEventManager().dispatchEvent(new EventUIValueChanged(value));
                             } else {
@@ -596,8 +596,8 @@ public final class ModuleListComponent extends ResizableHudComponent {
                     valueText.returnListener = new ComponentListener() {
                         @Override
                         public void onComponentEvent() {
-                            if (valueText.displayValue.length() > 0) {
-                                value.setValue(valueText.displayValue);
+                            if (valueText.getText().length() > 0) {
+                                value.setValue(valueText.getText());
                                 Seppuku.INSTANCE.getConfigManager().save(ModuleConfig.class); // save configs
                                 Seppuku.INSTANCE.getEventManager().dispatchEvent(new EventUIValueChanged(value));
                             } else {
@@ -640,7 +640,7 @@ public final class ModuleListComponent extends ResizableHudComponent {
                         @Override
                         public void onComponentEvent() {
                             final Regex regex = (Regex) value.getValue();
-                            regex.setPatternString(valueText.displayValue);
+                            regex.setPatternString(valueText.getText());
                             if(regex.getPattern() == null)
                                 Seppuku.INSTANCE.logfChat("%s - %s: Invalid or empty regular expression; no input will match with pattern.", module.getDisplayName(), value.getName());
                             Seppuku.INSTANCE.getConfigManager().save(ModuleConfig.class); // save configs

--- a/src/main/java/me/rigamortis/seppuku/impl/module/hidden/CommandsModule.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/module/hidden/CommandsModule.java
@@ -69,10 +69,6 @@ public final class CommandsModule extends Module {
         final Minecraft mc = Minecraft.getMinecraft();
         if (mc.player != null) {
             if (mc.currentScreen instanceof GuiChat) {
-                if (event.getKeyCode() == 15) { // tab
-                    event.setCanceled(true);
-                }
-
                 final int prefixLength = this.prefix.getValue().length();
                 String input = ((GuiChat) mc.currentScreen).inputField.getText();
 
@@ -81,6 +77,10 @@ public final class CommandsModule extends Module {
                 }
 
                 if (input.startsWith(this.prefix.getValue())) {
+                    if (event.getKeyCode() == 15) { // tab
+                        event.setCanceled(true);
+                    }
+
                     if (input.length() > prefixLength) {
                         input = input.substring(prefixLength);
                     }

--- a/src/main/java/me/rigamortis/seppuku/impl/module/movement/AutoWalkModule.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/module/movement/AutoWalkModule.java
@@ -25,8 +25,10 @@ public final class AutoWalkModule extends Module {
     public final Value<String> baritoneCommand = new Value<>("Command", new String[]{"Com", "C", "Text"}, "The message you want to send to communicate with baritone. (include prefix!)", "#explore");
     public final Value<String> baritoneCancelCommand = new Value<>("Cancel", new String[]{"BaritoneCancel", "Cancel", "Stop", "Text"}, "The cancel baritone command to send when disabled. (include prefix!)", "#cancel");
     public final Value<Float> waitTime = new Value<Float>("MsgDelay", new String[]{"MessageDelay", "CommandDelay", "Delay", "Wait", "Time", "md", "d"}, "Delay(ms) between sending baritone commands when standing.", 3000.0f, 0.0f, 8000.0f, 100.0f);
+    public final Value<Float> standingTime = new Value<Float>("StandingTime", new String[]{"SDelay", "StandingT", "StandingWait", "StandingW", "SWait", "st"}, "Time(ms) needed to count as standing still. Prevents re-pathing when rubberbanding", 250.0f, 0.0f, 4000.0f, 50.0f);
 
     private final Timer sendCommandTimer = new Timer();
+    private final Timer movementTimer = new Timer();
 
     public AutoWalkModule() {
         super("AutoWalk", new String[]{"AutomaticWalk"}, "Automatically presses the forward key or sends commands to baritone.", "NONE", -1, ModuleType.MOVEMENT);
@@ -95,8 +97,13 @@ public final class AutoWalkModule extends Module {
             }
 
             if (this.useBaritone.getValue()) {
-                boolean isStanding = Minecraft.getMinecraft().player.motionX == 0 && Minecraft.getMinecraft().player.motionZ == 0;
-                if (isStanding && this.sendCommandTimer.passed(this.waitTime.getValue())) {
+                boolean isStanding = true; // you could probably remove this flag now that there's a standing time check
+                if (Minecraft.getMinecraft().player.motionX != 0 || Minecraft.getMinecraft().player.motionZ != 0) {
+                    this.movementTimer.reset();
+                    isStanding = false;
+                }
+
+                if (isStanding && this.movementTimer.passed(this.standingTime.getValue()) && this.sendCommandTimer.passed(this.waitTime.getValue())) {
                     this.sendCommandTimer.reset();
                     this.sendBaritoneCommand();
                 }

--- a/src/main/java/me/rigamortis/seppuku/impl/module/render/StorageESPModule.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/module/render/StorageESPModule.java
@@ -251,8 +251,7 @@ public final class StorageESPModule extends Module {
         int baseColor;
         if (this.tracerStorageColor.getValue()) {
             baseColor = this.getBaseColor(te);
-        }
-        else {
+        } else {
             baseColor = this.tracerColor.getValue().getRGB();
         }
 

--- a/src/main/java/me/rigamortis/seppuku/impl/module/render/StorageESPModule.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/module/render/StorageESPModule.java
@@ -61,12 +61,6 @@ public final class StorageESPModule extends Module {
                                 // Box
                                 RenderUtil.drawOutlineRect(bounds[0], bounds[1], bounds[2], bounds[3], 1.5f, ColorUtil.changeAlpha(0xAA000000, this.opacity.getValue()));
                                 RenderUtil.drawOutlineRect(bounds[0] - 0.5f, bounds[1] - 0.5f, bounds[2] + 0.5f, bounds[3] + 0.5f, 0.5f, this.getBoxColor(te));
-
-                                // Line
-                                if (this.tracer.getValue()) {
-                                    final GLUProjection.Projection projection = GLUProjection.getInstance().project((bb.minX + bb.maxX) / 2, (bb.minY + bb.maxY) / 2, (bb.minZ + bb.maxZ) / 2, GLUProjection.ClampMode.NONE, true);
-                                    RenderUtil.drawLine((float) projection.getX(), (float) projection.getY(), event.getScaledResolution().getScaledWidth() / 2.0f, event.getScaledResolution().getScaledHeight() / 2.0f, this.tracerWidth.getValue(), this.getTracerColor(te));
-                                }
                             }
 
                             if (this.nametag.getValue()) {
@@ -75,6 +69,12 @@ public final class StorageESPModule extends Module {
                                 mc.fontRenderer.drawStringWithShadow(name, bounds[0] + (bounds[2] - bounds[0]) / 2 - mc.fontRenderer.getStringWidth(name) / 2, bounds[1] + (bounds[3] - bounds[1]) - mc.fontRenderer.FONT_HEIGHT - 1, ColorUtil.changeAlpha(0xFFFFFFFF, this.opacity.getValue()));
                                 GL11.glDisable(GL11.GL_BLEND);
                             }
+                        }
+
+                        // Line
+                        if (this.tracer.getValue()) {
+                            final GLUProjection.Projection projection = GLUProjection.getInstance().project((bb.minX + bb.maxX) / 2, (bb.minY + bb.maxY) / 2, (bb.minZ + bb.maxZ) / 2, GLUProjection.ClampMode.NONE, true);
+                            RenderUtil.drawLine((float) projection.getX(), (float) projection.getY(), event.getScaledResolution().getScaledWidth() / 2.0f, event.getScaledResolution().getScaledHeight() / 2.0f, this.tracerWidth.getValue(), this.getTracerColor(te));
                         }
                     }
                 }


### PR DESCRIPTION
- Only cancel tab key presses in commands module if necessary when predictions are enabled
  - Before it would always cancel tabs, breaking vanilla command auto-complete
- Add new property, standing time, to auto-walk module to prevent issues with rubber-banding when using high timer values
  - Before, it would think that baritone stopped because the player stood still for a single frame, causing baritone to re-path and sometimes fail because of that
- Fix wrong tracer destinations when using 3D tracers with bobbing enabled (this also changes lookVec in GLUProjections and adds a new getter; getCamPos)
- Added tracers to storage module, disabled by default
- TextComponent improved; you can now scroll the text with the arrow keys, partially select text by holding shift, copy and cut text instead of just pasting
- Key repeats are now enabled by default, meaning that you can now repeat keys other than delete and backspace in TextComponent
- Cleaned up a previous commit that added fluids to BlocksComponent; it uses RenderUtil now
- RenderUtil now uses GLStateManager when changing color to avoid issues

demo:
![demo](https://user-images.githubusercontent.com/15365765/130369223-3c237f9d-e8bc-4a58-84da-408a80b6140b.gif)

ps; i might add text selection with the mouse some other day if i keep getting annoyed by the text boxes
