### PR TITLE
Fix issues discussed in #80

### DIFF
--- a/src/main/java/me/rigamortis/seppuku/api/event/render/EventDrawNameplate.java
+++ b/src/main/java/me/rigamortis/seppuku/api/event/render/EventDrawNameplate.java
@@ -1,0 +1,31 @@
+package me.rigamortis.seppuku.api.event.render;
+
+import me.rigamortis.seppuku.api.event.EventCancellable;
+import net.minecraft.client.gui.FontRenderer;
+
+public class EventDrawNameplate extends EventCancellable {
+
+    public final FontRenderer fontRenderer;
+    public final String str;
+    public final float x;
+    public final float y;
+    public final float z;
+    public final int verticalShift;
+    public final float viewerYaw;
+    public final float viewerPitch;
+    public final boolean isThirdPersonFrontal;
+    public final boolean isSneaking;
+
+    public EventDrawNameplate(FontRenderer fontRenderer, String str, float x, float y, float z, int verticalShift, float viewerYaw, float viewerPitch, boolean isThirdPersonFrontal, boolean isSneaking) {
+        this.fontRenderer = fontRenderer;
+        this.str = str;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.verticalShift = verticalShift;
+        this.viewerYaw = viewerYaw;
+        this.viewerPitch = viewerPitch;
+        this.isThirdPersonFrontal = isThirdPersonFrontal;
+        this.isSneaking = isSneaking;
+    }
+}

--- a/src/main/java/me/rigamortis/seppuku/api/util/shader/ShaderProgram.java
+++ b/src/main/java/me/rigamortis/seppuku/api/util/shader/ShaderProgram.java
@@ -759,7 +759,7 @@ public class ShaderProgram {
             this.depthTextureCounter++;
 
             if (this.depthTextureCounter == 1) {
-                OpenGlHelper.setActiveTexture(GL_TEXTURE3); // nothing special about texture 3, it's just never used (at least in vanilla)
+                GlStateManager.setActiveTexture(GL_TEXTURE3); // nothing special about texture 3, it's just never used (at least in vanilla)
                 GlStateManager.enableTexture2D();
                 FramebufferUtil.bindDepthTexture();
             }
@@ -768,7 +768,7 @@ public class ShaderProgram {
             this.setUniform(DEPTHDIMS_UNIFORM, (float)FramebufferUtil.getWidth(), (float)FramebufferUtil.getHeight());
 
             if (this.depthTextureCounter == 1) {
-                OpenGlHelper.setActiveTexture(OpenGlHelper.defaultTexUnit);
+                GlStateManager.setActiveTexture(OpenGlHelper.defaultTexUnit);
             }
         }
     }
@@ -785,10 +785,10 @@ public class ShaderProgram {
             if (this.depthTextureCounter < 0) {
                 throw new RuntimeException("Too many depth texture unbinds; there's a bug somewhere, report this");
             } else if(this.depthTextureCounter == 0) {
-                OpenGlHelper.setActiveTexture(GL_TEXTURE3);
+                GlStateManager.setActiveTexture(GL_TEXTURE3);
                 GlStateManager.bindTexture(0);
                 GlStateManager.disableTexture2D();
-                OpenGlHelper.setActiveTexture(OpenGlHelper.defaultTexUnit);
+                GlStateManager.setActiveTexture(OpenGlHelper.defaultTexUnit);
             }
         }
     }

--- a/src/main/java/me/rigamortis/seppuku/impl/gui/hud/component/module/ModuleListComponent.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/gui/hud/component/module/ModuleListComponent.java
@@ -9,6 +9,7 @@ import me.rigamortis.seppuku.api.module.Module;
 import me.rigamortis.seppuku.api.texture.Texture;
 import me.rigamortis.seppuku.api.util.RenderUtil;
 import me.rigamortis.seppuku.api.value.Regex;
+import me.rigamortis.seppuku.api.value.Shader;
 import me.rigamortis.seppuku.api.value.Value;
 import me.rigamortis.seppuku.impl.config.ModuleConfig;
 import me.rigamortis.seppuku.impl.gui.hud.GuiHudEditor;
@@ -649,6 +650,11 @@ public final class ModuleListComponent extends ResizableHudComponent {
                     };
                     components.add(valueText);
                     this.addComponentToButtons(valueText);
+                } else if (value.getValue() instanceof Shader) {
+                    CarouselComponent carouselComponent = new CarouselComponent(value.getName(), value);
+                    carouselComponent.setTooltipText(value.getDesc());
+                    components.add(carouselComponent);
+                    this.addComponentToButtons(carouselComponent);
                 }
             }
         }

--- a/src/main/java/me/rigamortis/seppuku/impl/module/render/BlockHighlightModule.java
+++ b/src/main/java/me/rigamortis/seppuku/impl/module/render/BlockHighlightModule.java
@@ -9,6 +9,7 @@ import me.rigamortis.seppuku.api.value.Value;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
@@ -65,6 +66,7 @@ public final class BlockHighlightModule extends Module {
                 }
             }
 
+            GlStateManager.color(1.0f, 1.0f, 1.0f);
             RenderUtil.begin3D();
             final Vec3d interp = MathUtil.interpolateEntity(mc.player, mc.getRenderPartialTicks());
             final AxisAlignedBB bb = iblockstate.getSelectedBoundingBox(mc.world, blockpos).shrink(currentDamage / 2.0f).offset(-interp.x, -interp.y, -interp.z);


### PR DESCRIPTION
- fix blockhighlights not working properly. the issue was unrelated to the new shader system; color wasn't set before rendering the block highlight, but just in case i also set the color to fully white after finishing rendering entites
- fix nametags not being rendered properly (thanks @Old-Chum)
  - initially i just tried to do what old chum suggested but with the renderName hook instead; it has issues with the nametag background being fully transparent
  - then i tried drawNameplate instead; same issue
  - turns out i just wasn't setting active textures correctly (i was calling OpenGlHelper.setActiveTexture instead of GlStateManager.setActiveTexture), so the first method would have worked, but i just kept the new method. as a result, there is a new hook for drawNameplate
- added back carousel for changing shaders for a module's Shader value. somehow i removed this before creating the last pull request